### PR TITLE
[328801] Fix filled ellipse rendering

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScaledGraphics.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScaledGraphics.java
@@ -906,9 +906,9 @@ public class ScaledGraphics extends Graphics {
 	private Rectangle zoomFillRect(int x, int y, int w, int h) {
 		tempRECT.x = (int) (Math.floor((x * zoom + fractionalX)));
 		tempRECT.y = (int) (Math.floor((y * zoom + fractionalY)));
-		tempRECT.width = (int) (Math.floor(((x + w - 1) * zoom + fractionalX)))
+		tempRECT.width = (int) (Math.floor(((x + w) * zoom + fractionalX)))
 				- tempRECT.x + 1;
-		tempRECT.height = (int) (Math.floor(((y + h - 1) * zoom + fractionalY)))
+		tempRECT.height = (int) (Math.floor(((y + h) * zoom + fractionalY)))
 				- tempRECT.y + 1;
 		return tempRECT;
 	}


### PR DESCRIPTION
When rendering a filled ellipse on a scaled canvas, a small gap
can appear between the fill and the outline shape.
This happens because the outline of the Ellipse is drawn using the
scaled rectangle returned by zoomRect while the inner circle is drawn
using the rectangle returned by zoomFillrect and those rectangle centers
are not aligned.
This patch align those centers to fix this problem.

Signed-off-by: Jules Clero <julesx.clero@intel.com>

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=328801
Also-by: Sebastien Delestaing <sebastien.delestaing@intel.com>